### PR TITLE
Fix incompatibility with custom EntityPlayers

### DIFF
--- a/src/main/java/deez/togglesneak/ToggleSneakEvents.java
+++ b/src/main/java/deez/togglesneak/ToggleSneakEvents.java
@@ -31,16 +31,17 @@ public class ToggleSneakEvents {
         //Ignore server side events
         if (event.side.isServer())
             return;
-        //Ignore other EntityPlayers in multiplayer
-        if (event.player instanceof EntityOtherPlayerMP)
-            return;
-        EntityPlayerSP player = (EntityPlayerSP) event.player;
         //In case EntityPlayerSP is not initialized yet
-        if (player == null) {
+        if (event.player == null) {
             sprintToggleTimer = null;
             return;
         }
-        if (sprintToggleTimer == null)
+		//Ignore other EntityPlayers in multiplayer, or custom modded EntityPlayers
+		if (!(event.player instanceof EntityPlayerSP))
+			return;
+
+		EntityPlayerSP player = (EntityPlayerSP) event.player;
+		if (sprintToggleTimer == null)
             sprintToggleTimer = ReflectionHelper.findField(EntityPlayerSP.class, "field_71156_d", "sprintToggleTimer");
 
         boolean isSneaking = false;

--- a/src/main/java/deez/togglesneak/ToggleSneakEvents.java
+++ b/src/main/java/deez/togglesneak/ToggleSneakEvents.java
@@ -36,12 +36,12 @@ public class ToggleSneakEvents {
             sprintToggleTimer = null;
             return;
         }
-		//Ignore other EntityPlayers in multiplayer, or custom modded EntityPlayers
-		if (!(event.player instanceof EntityPlayerSP))
-			return;
+        //Ignore other EntityPlayers in multiplayer, or custom modded EntityPlayers
+        if (!(event.player instanceof EntityPlayerSP))
+            return;
 
-		EntityPlayerSP player = (EntityPlayerSP) event.player;
-		if (sprintToggleTimer == null)
+        EntityPlayerSP player = (EntityPlayerSP) event.player;
+        if (sprintToggleTimer == null)
             sprintToggleTimer = ReflectionHelper.findField(EntityPlayerSP.class, "field_71156_d", "sprintToggleTimer");
 
         boolean isSneaking = false;


### PR DESCRIPTION
This fixes a crash when a custom modded EntityPlayer is used, e.g. in the Armor Forge in Construct's Armory